### PR TITLE
chore(build): pypiデプロイ周りの調整

### DIFF
--- a/.github/workflows/build_and_deploy_infer.yml
+++ b/.github/workflows/build_and_deploy_infer.yml
@@ -7,7 +7,7 @@ on:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
       production:
-        description: "falseならTestPyPIにデプロイ、trueならpypi環境でPyPIにデプロイ"
+        description: "falseならTestPyPIにデプロイ、trueならpypi EnvironmentでPyPIにデプロイ"
         type: boolean
         required: false
         default: false

--- a/.github/workflows/build_and_deploy_infer.yml
+++ b/.github/workflows/build_and_deploy_infer.yml
@@ -1,4 +1,4 @@
-name: Build and release infer packages
+name: Build and deploy infer packages
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_and_deploy_infer.yml
+++ b/.github/workflows/build_and_deploy_infer.yml
@@ -7,7 +7,7 @@ on:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
       production:
-        description: "TestPyPIではなくPyPIにリリースする"
+        description: "falseならTestPyPIにデプロイ、trueならpypi環境でPyPIにデプロイ"
         type: boolean
         required: false
         default: false
@@ -76,7 +76,7 @@ jobs:
       id-token: write
       contents: write
 
-    environment: pypi
+    environment: ${{ inputs.production && 'pypi' || '' }}
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/build_and_release_infer.yml
+++ b/.github/workflows/build_and_release_infer.yml
@@ -76,7 +76,7 @@ jobs:
       id-token: write
       contents: write
 
-    environment: release-pypi
+    environment: pypi
 
     steps:
       - name: Download artifacts


### PR DESCRIPTION
## 内容

タイトルの通りです。

* 環境名をrelease-pypiからpypiに変更
	* 他のリポジトリの`github-pages`とかも`release-`が付いてないというのと、`production`も名詞のみなので
	* あと`release-[バージョン]`というブランチ名もあってかぶるかもというのもある。（こっちはそこまで重要じゃないけど）
* releaseをdeployに改名
	* 他のリポジトリではそうなっているので（こういう細かいところがOSS特有の不揃い感になるので、毎回他のリポジトリの名前を参照しに行った方が良さそう）
* production引数の役割を追加
	* 環境を指定するかどうかを制御できるようにしました
	* というのもこれでデプロイできる人を制限したかったので
	* 一旦僕と @sevenc-nanashi さんなら許可できるようにしてみました

## 関連 Issue

- https://github.com/VOICEVOX/kanalizer/issues/41#issuecomment-2762872843
## その他
