### PR TITLE
chore!(infer): C2kをKanalizerにリネーム

### DIFF
--- a/infer/crates/kanalizer-py/README.md
+++ b/infer/crates/kanalizer-py/README.md
@@ -9,10 +9,10 @@
 # 文字列をカタカナに変換する例
 import kanalizer
 
-c2k = kanalizer.C2k()
+kana = kanalizer.Kanalizer()
 
 word = "kanalizer"
-print(c2k(word)) # => カナライザー
+print(kana.infer(word)) # => カナライザー
 ```
 
 ## ライセンス

--- a/infer/crates/kanalizer-py/README.md
+++ b/infer/crates/kanalizer-py/README.md
@@ -7,12 +7,12 @@
 
 ```py
 # 文字列をカタカナに変換する例
-import kanalizer
+from kanalizer import Kanalizer
 
-kana = kanalizer.Kanalizer()
+kanalizer = Kanalizer()
 
 word = "kanalizer"
-print(kana.infer(word)) # => カナライザー
+print(kanalizer.infer(word)) # => カナライザー
 ```
 
 ## ライセンス

--- a/infer/crates/kanalizer-py/README.md
+++ b/infer/crates/kanalizer-py/README.md
@@ -12,7 +12,7 @@ from kanalizer import Kanalizer
 kanalizer = Kanalizer()
 
 word = "kanalizer"
-print(kanalizer.infer(word)) # => カナライザー
+print(kanalizer.convert(word)) # => カナライザー
 ```
 
 ## ライセンス

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -60,7 +60,7 @@ class Kanalizer:
 
         ...
 
-    def infer(self, word: str) -> str:
+    def convert(self, word: str) -> str:
         """
         推論を行う。
 

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -4,14 +4,14 @@ __version__: Final[str]
 """バージョン。"""
 
 KANAS: Final[list[str]]
-"""c2kの入力に使える文字の一覧。"""
+"""Kanalizerの入力に使える文字の一覧。"""
 ASCII_ENTRIES: Final[list[str]]
-"""c2kで出力される文字の一覧。"""
+"""Kanalizerで出力される文字の一覧。"""
 
 Strategy = Literal["greedy", "top_k", "top_p"]
 """デコードのアルゴリズム。"""
 
-class C2k:
+class Kanalizer:
     """英単語 -> カタカナの推論を行う。"""
 
     @overload
@@ -60,7 +60,7 @@ class C2k:
 
         ...
 
-    def __call__(self, word: str) -> str:
+    def infer(self, word: str) -> str:
         """
         推論を行う。
 

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -111,8 +111,8 @@ impl Kanalizer {
         })
     }
 
-    fn infer(&self, src: &str) -> String {
-        self.inner.read().unwrap().infer(src)
+    fn convert(&self, src: &str) -> String {
+        self.inner.read().unwrap().convert(src)
     }
 }
 

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -88,12 +88,12 @@ fn extract_strategy(
 }
 
 #[pyclass(frozen)]
-struct C2k {
-    inner: std::sync::RwLock<kanalizer::C2k>,
+struct Kanalizer {
+    inner: std::sync::RwLock<kanalizer::Kanalizer>,
 }
 
 #[pymethods]
-impl C2k {
+impl Kanalizer {
     #[new]
     #[pyo3(signature = (max_length = 32, strategy = "greedy", **kwargs))]
     fn new(
@@ -104,21 +104,21 @@ impl C2k {
         let strategy = extract_strategy(strategy, kwargs)?;
         Ok(Self {
             inner: std::sync::RwLock::new(
-                kanalizer::C2k::new()
+                kanalizer::Kanalizer::new()
                     .with_max_length(max_length)
                     .with_strategy(strategy),
             ),
         })
     }
 
-    fn __call__(&self, src: &str) -> String {
+    fn infer(&self, src: &str) -> String {
         self.inner.read().unwrap().infer(src)
     }
 }
 
 #[pymodule(name = "kanalizer")]
 fn init_kanalizer(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<C2k>()?;
+    m.add_class::<Kanalizer>()?;
 
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add("KANAS", kanalizer::KANAS)?;

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -1,7 +1,7 @@
 import kanalizer
 
 
-def test_c2k():
+def test_kana():
     kana = kanalizer.Kanalizer()
 
     word = "kanalizer"

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -2,7 +2,7 @@ import kanalizer
 
 
 def test_c2k():
-    c2k = kanalizer.C2k()
+    kana = kanalizer.Kanalizer()
 
     word = "kanalizer"
-    assert c2k(word) == "カナライザー"
+    assert kana.infer(word) == "カナライザー"

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -1,8 +1,8 @@
-import kanalizer
+from kanalizer import Kanalizer
 
 
-def test_kana():
-    kana = kanalizer.Kanalizer()
+def test_kanalizer():
+    kanalizer = Kanalizer()
 
     word = "kanalizer"
-    assert kana.infer(word) == "カナライザー"
+    assert kanalizer.infer(word) == "カナライザー"

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -5,4 +5,4 @@ def test_kanalizer():
     kanalizer = Kanalizer()
 
     word = "kanalizer"
-    assert kanalizer.infer(word) == "カナライザー"
+    assert kanalizer.convert(word) == "カナライザー"

--- a/infer/crates/kanalizer-rs/README.md
+++ b/infer/crates/kanalizer-rs/README.md
@@ -8,7 +8,7 @@
 // 文字列をカタカナに変換する例
 let src = "kanalizer";
 let kana = kanalizer::Kanalizer::new();
-let dst = kana.infer(src);
+let dst = kana.convert(src);
 
 assert_eq!(dst, "カナライザー");
 ```

--- a/infer/crates/kanalizer-rs/README.md
+++ b/infer/crates/kanalizer-rs/README.md
@@ -7,8 +7,8 @@
 ```rust
 // 文字列をカタカナに変換する例
 let src = "kanalizer";
-let kana = kanalizer::Kanalizer::new();
-let dst = kana.convert(src);
+let kanalizer = kanalizer::Kanalizer::new();
+let dst = kanalizer.convert(src);
 
 assert_eq!(dst, "カナライザー");
 ```

--- a/infer/crates/kanalizer-rs/README.md
+++ b/infer/crates/kanalizer-rs/README.md
@@ -7,8 +7,8 @@
 ```rust
 // 文字列をカタカナに変換する例
 let src = "kanalizer";
-let c2k = kanalizer::C2k::new();
-let dst = c2k.infer(src);
+let kana = kanalizer::Kanalizer::new();
+let dst = kana.infer(src);
 
 assert_eq!(dst, "カナライザー");
 ```

--- a/infer/crates/kanalizer-rs/benches/benchmark.rs
+++ b/infer/crates/kanalizer-rs/benches/benchmark.rs
@@ -3,7 +3,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Kanalizer", |b| {
         let kana = kanalizer::Kanalizer::new();
-        b.iter(|| std::hint::black_box(kana.infer("kanalizer")))
+        b.iter(|| std::hint::black_box(kana.convert("kanalizer")))
     });
 }
 

--- a/infer/crates/kanalizer-rs/benches/benchmark.rs
+++ b/infer/crates/kanalizer-rs/benches/benchmark.rs
@@ -1,9 +1,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("c2k", |b| {
-        let c2k = kanalizer::C2k::new();
-        b.iter(|| std::hint::black_box(c2k.infer("kanalizer")))
+    c.bench_function("Kanalizer", |b| {
+        let kana = kanalizer::Kanalizer::new();
+        b.iter(|| std::hint::black_box(kana.infer("kanalizer")))
     });
 }
 

--- a/infer/crates/kanalizer-rs/benches/benchmark.rs
+++ b/infer/crates/kanalizer-rs/benches/benchmark.rs
@@ -2,8 +2,8 @@ use criterion::{Criterion, criterion_group, criterion_main};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Kanalizer", |b| {
-        let kana = kanalizer::Kanalizer::new();
-        b.iter(|| std::hint::black_box(kana.convert("kanalizer")))
+        let kanalizer = kanalizer::Kanalizer::new();
+        b.iter(|| std::hint::black_box(kanalizer.convert("kanalizer")))
     });
 }
 

--- a/infer/crates/kanalizer-rs/examples/repl.rs
+++ b/infer/crates/kanalizer-rs/examples/repl.rs
@@ -64,7 +64,7 @@ fn main() {
             .with_prompt("Input")
             .interact()
             .unwrap();
-        let dst = kana.infer(&line);
+        let dst = kana.convert(&line);
         println!("{} -> {}", line, dst);
     }
 }

--- a/infer/crates/kanalizer-rs/examples/repl.rs
+++ b/infer/crates/kanalizer-rs/examples/repl.rs
@@ -54,7 +54,7 @@ fn main() {
         }
     };
 
-    let kana = kanalizer::Kanalizer::new()
+    let kanalizer = kanalizer::Kanalizer::new()
         .with_strategy(strategy)
         .with_max_length(args.max_length);
 
@@ -64,7 +64,7 @@ fn main() {
             .with_prompt("Input")
             .interact()
             .unwrap();
-        let dst = kana.convert(&line);
+        let dst = kanalizer.convert(&line);
         println!("{} -> {}", line, dst);
     }
 }

--- a/infer/crates/kanalizer-rs/examples/repl.rs
+++ b/infer/crates/kanalizer-rs/examples/repl.rs
@@ -54,7 +54,7 @@ fn main() {
         }
     };
 
-    let c2k = kanalizer::C2k::new()
+    let kana = kanalizer::Kanalizer::new()
         .with_strategy(strategy)
         .with_max_length(args.max_length);
 
@@ -64,7 +64,7 @@ fn main() {
             .with_prompt("Input")
             .interact()
             .unwrap();
-        let dst = c2k.infer(&line);
+        let dst = kana.infer(&line);
         println!("{} -> {}", line, dst);
     }
 }

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -403,7 +403,7 @@ impl Kanalizer {
     }
 
     /// 推論を行う。
-    pub fn infer(&self, input: &str) -> String {
+    pub fn convert(&self, input: &str) -> String {
         let input = input.chars().map(|c| c.to_string()).collect::<Vec<_>>();
         self.inner.infer(&input).into_iter().collect()
     }

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -317,23 +317,23 @@ impl<I: Hash + Eq, O: Clone> BaseE2k<I, O> {
 }
 
 /// 英単語 -> カタカナの変換器。
-pub struct C2k {
+pub struct Kanalizer {
     inner: BaseE2k<String, char>,
 }
 
-impl std::fmt::Debug for C2k {
+impl std::fmt::Debug for Kanalizer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("C2k").finish()
+        f.debug_struct("Kanalizer").finish()
     }
 }
 
-impl Default for C2k {
+impl Default for Kanalizer {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl C2k {
+impl Kanalizer {
     /// 新しいインスタンスを生成する。
     ///
     /// # See also

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -7,8 +7,8 @@
 //! ```rust
 //! // 文字列をカタカナに変換する例
 //! let src = "kanalizer";
-//! let c2k = kanalizer::C2k::new();
-//! let dst = c2k.infer(src);
+//! let kana = kanalizer::Kanalizer::new();
+//! let dst = kana.infer(src);
 //!
 //! assert_eq!(dst, "カナライザー");
 //! ```

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -7,8 +7,8 @@
 //! ```rust
 //! // 文字列をカタカナに変換する例
 //! let src = "kanalizer";
-//! let kana = kanalizer::Kanalizer::new();
-//! let dst = kana.convert(src);
+//! let kanalizer = kanalizer::Kanalizer::new();
+//! let dst = kanalizer.convert(src);
 //!
 //! assert_eq!(dst, "カナライザー");
 //! ```

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -8,7 +8,7 @@
 //! // 文字列をカタカナに変換する例
 //! let src = "kanalizer";
 //! let kana = kanalizer::Kanalizer::new();
-//! let dst = kana.infer(src);
+//! let dst = kana.convert(src);
 //!
 //! assert_eq!(dst, "カナライザー");
 //! ```

--- a/infer/crates/kanalizer-rs/tests/test_main.rs
+++ b/infer/crates/kanalizer-rs/tests/test_main.rs
@@ -3,7 +3,7 @@ fn test_kana() {
     let src = "kanalizer";
 
     let kana = kanalizer::Kanalizer::new();
-    let dst = kana.infer(src);
+    let dst = kana.convert(src);
     assert_eq!(dst, "カナライザー");
 }
 
@@ -12,7 +12,7 @@ fn test_kana_empty() {
     let src = "";
 
     let kanalizer = kanalizer::Kanalizer::new();
-    let dst = kanalizer.infer(src);
+    let dst = kanalizer.convert(src);
     assert_eq!(dst, "");
 }
 
@@ -22,8 +22,8 @@ fn test_kana_long() {
 
     let unlimited_kanalizer = kanalizer::Kanalizer::new();
     let limited_kanalizer = kanalizer::Kanalizer::new().with_max_length(10);
-    let unlimited_dst = unlimited_kanalizer.infer(src);
-    let limited_dst = limited_kanalizer.infer(src);
+    let unlimited_dst = unlimited_kanalizer.convert(src);
+    let limited_dst = limited_kanalizer.convert(src);
     assert_ne!(unlimited_dst, limited_dst);
     assert_eq!(limited_dst.chars().count(), 10);
 }

--- a/infer/crates/kanalizer-rs/tests/test_main.rs
+++ b/infer/crates/kanalizer-rs/tests/test_main.rs
@@ -11,8 +11,8 @@ fn test_kana() {
 fn test_kana_empty() {
     let src = "";
 
-    let kana = kanalizer::Kanalizer::new();
-    let dst = kana.infer(src);
+    let kanalizer = kanalizer::Kanalizer::new();
+    let dst = kanalizer.infer(src);
     assert_eq!(dst, "");
 }
 
@@ -20,10 +20,10 @@ fn test_kana_empty() {
 fn test_kana_long() {
     let src = "pneumonoultramicroscopicsilicovolcanoconiosis";
 
-    let unlimited_kana = kanalizer::Kanalizer::new();
-    let limited_kana = kanalizer::Kanalizer::new().with_max_length(10);
-    let unlimited_dst = unlimited_kana.infer(src);
-    let limited_dst = limited_kana.infer(src);
+    let unlimited_kanalizer = kanalizer::Kanalizer::new();
+    let limited_kanalizer = kanalizer::Kanalizer::new().with_max_length(10);
+    let unlimited_dst = unlimited_kanalizer.infer(src);
+    let limited_dst = limited_kanalizer.infer(src);
     assert_ne!(unlimited_dst, limited_dst);
     assert_eq!(limited_dst.chars().count(), 10);
 }

--- a/infer/crates/kanalizer-rs/tests/test_main.rs
+++ b/infer/crates/kanalizer-rs/tests/test_main.rs
@@ -1,14 +1,14 @@
 #[test]
-fn test_kana() {
+fn test_kanalizer() {
     let src = "kanalizer";
 
-    let kana = kanalizer::Kanalizer::new();
-    let dst = kana.convert(src);
+    let kanalizer = kanalizer::Kanalizer::new();
+    let dst = kanalizer.convert(src);
     assert_eq!(dst, "カナライザー");
 }
 
 #[test]
-fn test_kana_empty() {
+fn test_kanalizer_empty() {
     let src = "";
 
     let kanalizer = kanalizer::Kanalizer::new();
@@ -17,7 +17,7 @@ fn test_kana_empty() {
 }
 
 #[test]
-fn test_kana_long() {
+fn test_kanalizer_long() {
     let src = "pneumonoultramicroscopicsilicovolcanoconiosis";
 
     let unlimited_kanalizer = kanalizer::Kanalizer::new();

--- a/infer/crates/kanalizer-rs/tests/test_main.rs
+++ b/infer/crates/kanalizer-rs/tests/test_main.rs
@@ -1,29 +1,29 @@
 #[test]
-fn test_c2k() {
+fn test_kana() {
     let src = "kanalizer";
 
-    let c2k = kanalizer::C2k::new();
-    let dst = c2k.infer(src);
+    let kana = kanalizer::Kanalizer::new();
+    let dst = kana.infer(src);
     assert_eq!(dst, "カナライザー");
 }
 
 #[test]
-fn test_c2k_empty() {
+fn test_kana_empty() {
     let src = "";
 
-    let c2k = kanalizer::C2k::new();
-    let dst = c2k.infer(src);
+    let kana = kanalizer::Kanalizer::new();
+    let dst = kana.infer(src);
     assert_eq!(dst, "");
 }
 
 #[test]
-fn test_c2k_long() {
+fn test_kana_long() {
     let src = "pneumonoultramicroscopicsilicovolcanoconiosis";
 
-    let unlimited_c2k = kanalizer::C2k::new();
-    let limited_c2k = kanalizer::C2k::new().with_max_length(10);
-    let unlimited_dst = unlimited_c2k.infer(src);
-    let limited_dst = limited_c2k.infer(src);
+    let unlimited_kana = kanalizer::Kanalizer::new();
+    let limited_kana = kanalizer::Kanalizer::new().with_max_length(10);
+    let unlimited_dst = unlimited_kana.infer(src);
+    let limited_dst = limited_kana.infer(src);
     assert_ne!(unlimited_dst, limited_dst);
     assert_eq!(limited_dst.chars().count(), 10);
 }


### PR DESCRIPTION
## 内容

C2kをKanalizerにリネームします。
このPRではinferのクラス/StructのC2kのみをリネームしています。
- model-c2k.safetensors
- train内

は悩み中...

## 関連 Issue

- ref: #48 

## スクリーンショット・動画など

（なし）

## その他

（なし）