### PR TITLE
fix(infer): kanalizer-pyのビルドを修正（/work -> /work/infer、Win32ビルドのPython指定）

### DIFF
--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -6,6 +6,7 @@ kanalizer-pyをビルドする。
 """
 
 # TODO: wheelビルドなどを別ファイルに分割し、build_kanalizer_py_docker.shと循環参照しないようにする
+# https://github.com/VOICEVOX/kanalizer/pull/54#discussion_r2023809776
 
 import argparse
 import os

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -36,7 +36,7 @@ def main():
         build_wheel()
         if is_windows:
             print("Building 32-bit wheel...")
-            build_wheel("i686-pc-windows-msvc")
+            build_wheel(target="i686-pc-windows-msvc", python_arch="x86")
         elif is_linux:
             print("Removing non-manylinux wheels...")
             remove_non_manylinux_wheels()
@@ -69,7 +69,7 @@ def process_args():
 
 
 def build_notice():
-    result = print_and_check_output(
+    print_and_run(
         [
             "cargo",
             "about",
@@ -77,10 +77,11 @@ def build_notice():
             "-c",
             infer_root / "tools" / "about.toml",
             infer_root / "tools" / "about.hbs.md",
+            "-o",
+            kanalizer_py_root / "NOTICE.md",
         ],
         cwd=kanalizer_py_root,
     )
-    (kanalizer_py_root / "NOTICE.md").write_bytes(result)
 
 
 def build_wheel(*, python_arch: str | None = None, target: str | None = None):

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -85,6 +85,7 @@ def build_notice():
 
 
 def build_wheel(*, python_arch: str | None = None, target: str | None = None):
+    # TODO: targetとpython_archの指定を必須にする
     target_args = []
     if target is not None:
         target_args = ["--target", target]

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -5,6 +5,8 @@ kanalizer-pyをビルドする。
 環境構築やレジストリへの公開はこのファイルでは行わない。
 """
 
+# TODO: wheelビルドなどを別ファイルに分割し、build_kanalizer_py_docker.shと循環参照しないようにする
+
 import argparse
 import os
 from pathlib import Path

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -12,7 +12,7 @@ import platform
 import shutil
 from subprocess import check_output, run
 import tempfile
-from common import infer_root, is_windows, is_linux
+from common import infer_root, is_windows, is_linux, os_name
 
 kanalizer_py_root = infer_root / "crates" / "kanalizer-py"
 wheels_root = infer_root / "target" / "wheels"
@@ -83,13 +83,19 @@ def build_notice():
     (kanalizer_py_root / "NOTICE.md").write_bytes(result)
 
 
-def build_wheel(target: str | None = None):
-    if target is None:
-        print_and_run(["uv", "run", "maturin", "build", "--release"])
-    else:
-        print_and_run(
-            ["uv", "run", "maturin", "build", "--release", "--target", target]
-        )
+def build_wheel(*, python_arch: str | None = None, target: str | None = None):
+    target_args = []
+    if target is not None:
+        target_args = ["--target", target]
+    python_arch_args = []
+    if python_arch is not None:
+        python_arch_args = [
+            "--python",
+            f"cpython-{platform.python_version}-{os_name}-{python_arch}",
+        ]
+    print_and_run(
+        ["uv", "run", *python_arch_args, "maturin", "build", "--release", *target_args]
+    )
 
 
 def remove_non_manylinux_wheels():

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -12,7 +12,7 @@ import platform
 import shutil
 from subprocess import check_output, run
 import tempfile
-from common import infer_root, is_windows, is_linux, os_name
+from common import infer_root, is_windows, is_linux
 
 kanalizer_py_root = infer_root / "crates" / "kanalizer-py"
 wheels_root = infer_root / "target" / "wheels"
@@ -90,6 +90,11 @@ def build_wheel(*, python_arch: str | None = None, target: str | None = None):
         target_args = ["--target", target]
     python_arch_args = []
     if python_arch is not None:
+        os_name = {
+            "Windows": "windows",
+            "Linux": "linux",
+            "Darwin": "macos",
+        }[platform.system()]
         python_arch_args = [
             "--python",
             f"cpython-{platform.python_version()}-{os_name}-{python_arch}",

--- a/infer/tools/build_kanalizer_py.py
+++ b/infer/tools/build_kanalizer_py.py
@@ -92,7 +92,7 @@ def build_wheel(*, python_arch: str | None = None, target: str | None = None):
     if python_arch is not None:
         python_arch_args = [
             "--python",
-            f"cpython-{platform.python_version}-{os_name}-{python_arch}",
+            f"cpython-{platform.python_version()}-{os_name}-{python_arch}",
         ]
     print_and_run(
         ["uv", "run", *python_arch_args, "maturin", "build", "--release", *target_args]

--- a/infer/tools/build_kanalizer_py_docker.sh
+++ b/infer/tools/build_kanalizer_py_docker.sh
@@ -15,7 +15,7 @@ curl -LsSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
 
 # ファイルをコピー
-mkdir /work
+mkdir -p /work/infer
 cat <<EOF > /work/copy_excludes.txt
 .venv
 target
@@ -23,11 +23,11 @@ __pycache__
 dist
 .pytest_cache
 EOF
-rsync -av --exclude-from=/work/copy_excludes.txt /mnt/infer/ /work
+rsync -av --exclude-from=/work/copy_excludes.txt /mnt/infer/ /work/infer
 
 # ビルド
-cd /work/tools
+cd /work/infer/tools
 uv run ./build_kanalizer_py.py --wheel --skip-notice
 
-chown $HOST_UID:$HOST_GID /work/target/wheels/*
-cp -rp /work/target/wheels/* /mnt/infer/target/wheels/
+chown $HOST_UID:$HOST_GID /work/infer/target/wheels/*
+cp -rp /work/infer/target/wheels/* /mnt/infer/target/wheels/

--- a/infer/tools/build_kanalizer_py_docker.sh
+++ b/infer/tools/build_kanalizer_py_docker.sh
@@ -15,7 +15,7 @@ curl -LsSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
 
 # ファイルをコピー
-mkdir -p /work/infer
+mkdir -p /work/infer  # ビルドスクリプトはリポジトリの構造に依存しているので、それを可能な限り模倣する。
 cat <<EOF > /work/copy_excludes.txt
 .venv
 target

--- a/infer/tools/common.py
+++ b/infer/tools/common.py
@@ -6,19 +6,5 @@ repo_root: Final[Path] = Path(__file__).parent.parent.parent
 infer_root: Final[Path] = repo_root / "infer"
 train_root: Final[Path] = repo_root / "train"
 
-# pyrightはelif内もFinalへの再代入として認識するため、Finalを外した変数を用意してそれをFinalに代入する
-_os_name: str
-
-if platform.system() == "Windows":
-    _os_name = "windows"
-elif platform.system() == "Linux":
-    _os_name = "linux"
-elif platform.system() == "Darwin":
-    _os_name = "macos"
-else:
-    raise RuntimeError(f"Unsupported platform: {platform.system()}")
-
-os_name: Final[str] = _os_name
-
-is_windows: Final[bool] = os_name == "windows"
-is_linux: Final[bool] = os_name == "linux"
+is_windows: Final[bool] = platform.system() == "Windows"
+is_linux: Final[bool] = platform.system() == "Linux"

--- a/infer/tools/common.py
+++ b/infer/tools/common.py
@@ -6,5 +6,19 @@ repo_root: Final[Path] = Path(__file__).parent.parent.parent
 infer_root: Final[Path] = repo_root / "infer"
 train_root: Final[Path] = repo_root / "train"
 
-is_windows: Final[bool] = platform.system() == "Windows"
-is_linux: Final[bool] = platform.system() == "Linux"
+# pyrightはelif内もFinalへの再代入として認識するため、Finalを外した変数を用意してそれをFinalに代入する
+_os_name: str
+
+if platform.system() == "Windows":
+    _os_name = "windows"
+elif platform.system() == "Linux":
+    _os_name = "linux"
+elif platform.system() == "Darwin":
+    _os_name = "macos"
+else:
+    raise RuntimeError(f"Unsupported platform: {platform.system()}")
+
+os_name: Final[str] = _os_name
+
+is_windows: Final[bool] = os_name == "windows"
+is_linux: Final[bool] = os_name == "linux"


### PR DESCRIPTION
## 内容

- Docker：`/work`を`/work/infer`にします。
- Windows：Python x86を指定するようにします。

## 関連 Issue
（なし）

## スクリーンショット・動画など

（なし）
## その他
（なし）