### PR TITLE
feat(infer): Kanalizerをシングルトンにする

### DIFF
--- a/infer/crates/kanalizer-py/README.md
+++ b/infer/crates/kanalizer-py/README.md
@@ -7,9 +7,7 @@
 
 ```py
 # 文字列をカタカナに変換する例
-from kanalizer import Kanalizer
-
-kanalizer = Kanalizer()
+import kanalizer
 
 word = "kanalizer"
 print(kanalizer.convert(word)) # => カナライザー

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -13,7 +13,7 @@ Strategy = Literal["greedy", "top_k", "top_p"]
 
 @overload
 def convert(
-    input: str,
+    word: str,
     /,
     *,
     max_length: int = 32,
@@ -21,7 +21,7 @@ def convert(
 ) -> str: ...
 @overload
 def convert(
-    input: str,
+    word: str,
     /,
     *,
     max_length: int = 32,
@@ -30,7 +30,7 @@ def convert(
 ) -> str: ...
 @overload
 def convert(
-    input: str,
+    word: str,
     /,
     *,
     max_length: int = 32,
@@ -39,14 +39,14 @@ def convert(
     t: float = 1.0,
 ) -> str: ...
 def convert(
-    input: str, /, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
+    word: str, /, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
 ) -> str:
     """
     推論を行う。
 
     Parameters
     ----------
-    input : str
+    word : str
         英単語。
     max_length : int, default 32
         最大の出力長。

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -18,7 +18,7 @@ def convert(
     *,
     max_length: int = 32,
     strategy: Literal["greedy"] = "greedy",
-) -> None: ...
+) -> str: ...
 @overload
 def convert(
     input: str,
@@ -27,7 +27,7 @@ def convert(
     max_length: int = 32,
     strategy: Literal["top_k"],
     k: int = 10,
-) -> None: ...
+) -> str: ...
 @overload
 def convert(
     input: str,
@@ -37,10 +37,10 @@ def convert(
     strategy: Literal["top_p"],
     p: float = 0.9,
     t: float = 1.0,
-) -> None: ...
+) -> str: ...
 def convert(
     input: str, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
-) -> None:
+) -> str:
     """
     推論を行う。
 

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -11,67 +11,52 @@ ASCII_ENTRIES: Final[list[str]]
 Strategy = Literal["greedy", "top_k", "top_p"]
 """デコードのアルゴリズム。"""
 
-class Kanalizer:
-    """英単語 -> カタカナの推論を行う。"""
+@overload
+def convert(
+    input: str,
+    /,
+    *,
+    max_length: int = 32,
+    strategy: Literal["greedy"] = "greedy",
+) -> None: ...
+@overload
+def convert(
+    input: str,
+    /,
+    *,
+    max_length: int = 32,
+    strategy: Literal["top_k"],
+    k: int = 10,
+) -> None: ...
+@overload
+def convert(
+    input: str,
+    /,
+    *,
+    max_length: int = 32,
+    strategy: Literal["top_p"],
+    p: float = 0.9,
+    t: float = 1.0,
+) -> None: ...
+def convert(
+    input: str, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
+) -> None:
+    """
+    推論を行う。
 
-    @overload
-    def __init__(
-        self,
-        *,
-        max_length: int = 32,
-        strategy: Literal["greedy"] = "greedy",
-    ) -> None: ...
-    @overload
-    def __init__(
-        self,
-        *,
-        max_length: int = 32,
-        strategy: Literal["top_k"],
-        k: int = 10,
-    ) -> None: ...
-    @overload
-    def __init__(
-        self,
-        *,
-        max_length: int = 32,
-        strategy: Literal["top_p"],
-        p: float = 0.9,
-        t: float = 1.0,
-    ) -> None: ...
-    def __init__(
-        self, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
-    ) -> None:
-        """
-        新しいインスタンスを生成する。
-
-        Parameters
-        ----------
-        max_length : int, default 32
-            最大の出力長。
-        strategy : Strategy, default "greedy"
-            デコードのアルゴリズム。
-        k : int, default 10
-            strategy="top_k"のときのみ有効。Top-KアルゴリズムのK。
-        p : float, default 0.9
-            strategy="top_p"のときのみ有効。Top-PアルゴリズムのP。
-        t : float, default 1.0
-            strategy="top_p"のときのみ有効。Top-PアルゴリズムのTemperature。
-        """
-
-        ...
-
-    def convert(self, word: str) -> str:
-        """
-        推論を行う。
-
-        Parameters
-        ----------
-        word : str
-            英単語。
-
-        Returns
-        -------
-        str
-            カタカナ。
-        """
-        ...
+    Parameters
+    ----------
+    input : str
+        英単語。
+    max_length : int, default 32
+        最大の出力長。
+    strategy : Strategy, default "greedy"
+        デコードのアルゴリズム。
+    k : int, default 10
+        strategy="top_k"のときのみ有効。Top-KアルゴリズムのK。
+    p : float, default 0.9
+        strategy="top_p"のときのみ有効。Top-PアルゴリズムのP。
+    t : float, default 1.0
+        strategy="top_p"のときのみ有効。Top-PアルゴリズムのTemperature。
+    """
+    ...

--- a/infer/crates/kanalizer-py/kanalizer.pyi
+++ b/infer/crates/kanalizer-py/kanalizer.pyi
@@ -39,7 +39,7 @@ def convert(
     t: float = 1.0,
 ) -> str: ...
 def convert(
-    input: str, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
+    input: str, /, *, max_length: int = 32, strategy: Strategy = "greedy", **kwargs
 ) -> str:
     """
     推論を行う。

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -88,15 +88,15 @@ fn extract_strategy(
 }
 
 #[pyfunction]
-#[pyo3(signature = (input, /, *, max_length = 32, strategy = "greedy", **kwargs))]
+#[pyo3(signature = (word, /, *, max_length = 32, strategy = "greedy", **kwargs))]
 fn convert(
-    input: &str,
+    word: &str,
     max_length: usize,
     strategy: &str,
     kwargs: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<String> {
     let strategy = extract_strategy(strategy, kwargs)?;
-    Ok(kanalizer::convert(input)
+    Ok(kanalizer::convert(word)
         .with_max_length(max_length)
         .with_strategy(&strategy)
         .perform())

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -87,42 +87,27 @@ fn extract_strategy(
     }
 }
 
-#[pyclass(frozen)]
-struct Kanalizer {
-    inner: std::sync::RwLock<kanalizer::Kanalizer>,
-}
-
-#[pymethods]
-impl Kanalizer {
-    #[new]
-    #[pyo3(signature = (max_length = 32, strategy = "greedy", **kwargs))]
-    fn new(
-        max_length: usize,
-        strategy: &str,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<Self> {
-        let strategy = extract_strategy(strategy, kwargs)?;
-        Ok(Self {
-            inner: std::sync::RwLock::new(
-                kanalizer::Kanalizer::new()
-                    .with_max_length(max_length)
-                    .with_strategy(strategy),
-            ),
-        })
-    }
-
-    fn convert(&self, src: &str) -> String {
-        self.inner.read().unwrap().convert(src)
-    }
+#[pyfunction]
+#[pyo3(signature = (input, /, *, max_length = 32, strategy = "greedy", **kwargs))]
+fn convert(
+    input: &str,
+    max_length: usize,
+    strategy: &str,
+    kwargs: Option<&Bound<'_, PyDict>>,
+) -> PyResult<String> {
+    let strategy = extract_strategy(strategy, kwargs)?;
+    Ok(kanalizer::convert(input)
+        .with_max_length(max_length)
+        .with_strategy(&strategy)
+        .perform())
 }
 
 #[pymodule(name = "kanalizer")]
 fn init_kanalizer(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Kanalizer>()?;
-
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add("KANAS", kanalizer::KANAS)?;
     m.add("ASCII_ENTRIES", kanalizer::ASCII_ENTRIES)?;
+    m.add_function(wrap_pyfunction!(convert, m)?)?;
 
     Ok(())
 }

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -1,8 +1,6 @@
-from kanalizer import Kanalizer
+import kanalizer
 
 
 def test_kanalizer():
-    kanalizer = Kanalizer()
-
     word = "kanalizer"
     assert kanalizer.convert(word) == "カナライザー"

--- a/infer/crates/kanalizer-rs/benches/benchmark.rs
+++ b/infer/crates/kanalizer-rs/benches/benchmark.rs
@@ -3,7 +3,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("Kanalizer", |b| {
         let kanalizer = kanalizer::Kanalizer::new();
-        b.iter(|| std::hint::black_box(kanalizer.convert("kanalizer")))
+        b.iter(|| std::hint::black_box(kanalizer.convert("kanalizer", &Default::default())))
     });
 }
 

--- a/infer/crates/kanalizer-rs/examples/repl.rs
+++ b/infer/crates/kanalizer-rs/examples/repl.rs
@@ -54,17 +54,16 @@ fn main() {
         }
     };
 
-    let kanalizer = kanalizer::Kanalizer::new()
-        .with_strategy(strategy)
-        .with_max_length(args.max_length);
-
     println!("Ctrl-C で終了します。");
     loop {
         let line = dialoguer::Input::<String>::new()
             .with_prompt("Input")
             .interact()
             .unwrap();
-        let dst = kanalizer.convert(&line);
+        let dst = kanalizer::convert(&line)
+            .with_max_length(args.max_length)
+            .with_strategy(&strategy)
+            .perform();
         println!("{} -> {}", line, dst);
     }
 }

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -398,4 +398,3 @@ impl Kanalizer {
         self.inner.infer(&input, options).into_iter().collect()
     }
 }
-

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use std::{collections::HashMap, hash::Hash};
 
 #[derive(Clone, Debug)]
+/// [Kanalizer::convert]のオプション。
 pub struct ConvertOptions {
     /// デコードの最大長。
     pub max_length: usize,
@@ -397,3 +398,4 @@ impl Kanalizer {
         self.inner.infer(&input, options).into_iter().collect()
     }
 }
+

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -1,6 +1,6 @@
 //! # kanalizer-rs
 //!
-//! [Patchethium氏のkanalizer](https://github.com/Patchethium/kanalizer)をRustに移植したものです。
+//! [Patchethium氏のe2k](https://github.com/Patchethium/e2k)をRustに移植したものです。
 //!
 //! ## 使い方
 //!
@@ -34,6 +34,7 @@ pub use inference::*;
 
 static KANALIZER: LazyLock<Kanalizer> = LazyLock::new(Kanalizer::new);
 
+/// 推論を行うためのオプションを指定する構造体。
 pub struct ConvertBuilder {
     input: String,
     options: ConvertOptions,

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -36,14 +36,14 @@ static KANALIZER: LazyLock<Kanalizer> = LazyLock::new(Kanalizer::new);
 
 /// 推論を行うためのオプションを指定する構造体。
 pub struct ConvertBuilder {
-    input: String,
+    word: String,
     options: ConvertOptions,
 }
 
 impl ConvertBuilder {
-    fn new(input: &str) -> Self {
+    fn new(word: &str) -> Self {
         Self {
-            input: input.to_string(),
+            word: word.to_string(),
             options: ConvertOptions::default(),
         }
     }
@@ -62,11 +62,11 @@ impl ConvertBuilder {
 
     /// 推論を行う。
     pub fn perform(self) -> String {
-        KANALIZER.convert(&self.input, &self.options)
+        KANALIZER.convert(&self.word, &self.options)
     }
 }
 
 /// 推論を行う。
-pub fn convert(input: &str) -> ConvertBuilder {
-    ConvertBuilder::new(input)
+pub fn convert(word: &str) -> ConvertBuilder {
+    ConvertBuilder::new(word)
 }

--- a/infer/crates/kanalizer-rs/tests/test_main.rs
+++ b/infer/crates/kanalizer-rs/tests/test_main.rs
@@ -3,7 +3,7 @@ fn test_kanalizer() {
     let src = "kanalizer";
 
     let kanalizer = kanalizer::Kanalizer::new();
-    let dst = kanalizer.convert(src);
+    let dst = kanalizer.convert(src, &Default::default());
     assert_eq!(dst, "カナライザー");
 }
 
@@ -12,18 +12,29 @@ fn test_kanalizer_empty() {
     let src = "";
 
     let kanalizer = kanalizer::Kanalizer::new();
-    let dst = kanalizer.convert(src);
+    let dst = kanalizer.convert(src, &Default::default());
     assert_eq!(dst, "");
 }
 
 #[test]
 fn test_kanalizer_long() {
-    let src = "pneumonoultramicroscopicsilicovolcanoconiosis";
+    let src = "phosphoribosylaminoimidazolesuccinocarboxamide";
 
-    let unlimited_kanalizer = kanalizer::Kanalizer::new();
-    let limited_kanalizer = kanalizer::Kanalizer::new().with_max_length(10);
-    let unlimited_dst = unlimited_kanalizer.convert(src);
-    let limited_dst = limited_kanalizer.convert(src);
+    let kanalizer = kanalizer::Kanalizer::new();
+    let unlimited_dst = kanalizer.convert(
+        src,
+        &kanalizer::ConvertOptions {
+            max_length: 32,
+            ..Default::default()
+        },
+    );
+    let limited_dst = kanalizer.convert(
+        src,
+        &kanalizer::ConvertOptions {
+            max_length: 10,
+            ..Default::default()
+        },
+    );
     assert_ne!(unlimited_dst, limited_dst);
     assert_eq!(limited_dst.chars().count(), 10);
 }


### PR DESCRIPTION
## 内容

APIを刷新します。
- Kanalizerをシングルトンにする。
- `crate::convert`をはやし、builderスタイルで設定できるようにする。
- Python APIを`convert`のみにする。
  - メンテの手間を考えるとconvertだけでいいかなぁと。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）