### PR TITLE
chore!(train): 一部のカタカナと記号を削除

### DIFF
--- a/train/src/constants.py
+++ b/train/src/constants.py
@@ -85,8 +85,6 @@ kanas = [
     "ロ",
     "ヮ",
     "ワ",
-    "ヰ",
-    "ヱ",
     "ヲ",
     "ン",
     "ヴ",
@@ -165,7 +163,7 @@ en_phones = [
     "ZH",
 ]
 
-ascii_entries = ["<pad>", "<sos>", "<eos>"] + list(ascii_lowercase) + [" ", "'"]
+ascii_entries = ["<pad>", "<sos>", "<eos>"] + list(ascii_lowercase)
 
 kanas = ["<pad>", "<sos>", "<eos>"] + kanas
 en_phones = ["<pad>", "<sos>", "<eos>"] + en_phones + [" ", "'"]

--- a/train/src/constants.py
+++ b/train/src/constants.py
@@ -1,7 +1,6 @@
 from string import ascii_lowercase
 
 
-PAD_IDX = 0
 SOS_IDX = 1
 EOS_IDX = 2
 
@@ -91,79 +90,6 @@ kanas = [
     "ー",
 ]
 
-en_phones = [
-    "AA0",
-    "AA1",
-    "AA2",
-    "AE0",
-    "AE1",
-    "AE2",
-    "AH0",
-    "AH1",
-    "AH2",
-    "AO0",
-    "AO1",
-    "AO2",
-    "AW0",
-    "AW1",
-    "AW2",
-    "AY0",
-    "AY1",
-    "AY2",
-    "B",
-    "CH",
-    "D",
-    "DH",
-    "EH0",
-    "EH1",
-    "EH2",
-    "ER0",
-    "ER1",
-    "ER2",
-    "EY0",
-    "EY1",
-    "EY2",
-    "F",
-    "G",
-    "HH",
-    "IH0",
-    "IH1",
-    "IH2",
-    "IY0",
-    "IY1",
-    "IY2",
-    "JH",
-    "K",
-    "L",
-    "M",
-    "N",
-    "NG",
-    "OW0",
-    "OW1",
-    "OW2",
-    "OY0",
-    "OY1",
-    "OY2",
-    "P",
-    "R",
-    "S",
-    "SH",
-    "T",
-    "TH",
-    "UH0",
-    "UH1",
-    "UH2",
-    "UW0",
-    "UW1",
-    "UW2",
-    "V",
-    "W",
-    "Y",
-    "Z",
-    "ZH",
-]
+ascii_entries = ["<sos>", "<eos>"] + list(ascii_lowercase)
 
-ascii_entries = ["<pad>", "<sos>", "<eos>"] + list(ascii_lowercase)
-
-kanas = ["<pad>", "<sos>", "<eos>"] + kanas
-en_phones = ["<pad>", "<sos>", "<eos>"] + en_phones + [" ", "'"]
+kanas = ["<sos>", "<eos>"] + kanas

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -21,7 +21,7 @@ from tqdm.auto import tqdm
 import yaml
 
 from config import Config
-from constants import EOS_IDX, PAD_IDX, SOS_IDX, ascii_entries, en_phones, kanas
+from constants import EOS_IDX, SOS_IDX, ascii_entries, en_phones, kanas
 from evaluator import Evaluator
 
 
@@ -105,7 +105,6 @@ class MyDataset(Dataset):
         self.eng_dict = {c: i for i, c in enumerate(en_phones)}
         self.c_dict = {c: i for i, c in enumerate(ascii_entries)}
         self.kata_dict = {c: i for i, c in enumerate(kanas)}
-        self.pad_idx = PAD_IDX
         self.sos_idx = SOS_IDX
         self.eos_idx = EOS_IDX
         self.cache_en = {}

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -21,7 +21,7 @@ from tqdm.auto import tqdm
 import yaml
 
 from config import Config
-from constants import EOS_IDX, SOS_IDX, ascii_entries, en_phones, kanas
+from constants import EOS_IDX, SOS_IDX, ascii_entries, kanas
 from evaluator import Evaluator
 
 
@@ -102,7 +102,6 @@ class MyDataset(Dataset):
         if max_words is not None:
             self.data = random.sample(self.data, min(max_words, len(self.data)))
         self.device = device
-        self.eng_dict = {c: i for i, c in enumerate(en_phones)}
         self.c_dict = {c: i for i, c in enumerate(ascii_entries)}
         self.kata_dict = {c: i for i, c in enumerate(kanas)}
         self.sos_idx = SOS_IDX


### PR DESCRIPTION
## 内容

ヰ、ヱ、` `、`'`、pad、EN_PHONESを削除します。これがマージされたら学習を回しなおす予定。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

inferの更新はモデルと同時に更新します。