### PR TITLE
feat(infer): 必ず1文字以上を推論する

### DIFF
--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -282,7 +282,7 @@ impl S2s {
 
             // 1文字目の場合は、終了トークンが出力されないようにする。
             if i == 0 {
-                x[(0, constants::EOS_IDX,)] = 0.0;
+                x[(0, constants::EOS_IDX)] = 0.0;
             }
 
             let x = x.index_axis(ndarray::Axis(0), 0);

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -282,7 +282,7 @@ impl S2s {
 
             // 1文字目の場合は、終了トークンが出力されないようにする。
             if i == 0 {
-                x[(0, constants::EOS_IDX)] = 0.0;
+                x[(0, constants::EOS_IDX)] = f32::MIN;
             }
 
             let x = x.index_axis(ndarray::Axis(0), 0);

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -256,7 +256,7 @@ impl S2s {
         let mut result = vec![constants::SOS_IDX];
         let mut h1: Option<ndarray::Array1<f32>> = None;
         let mut h2: Option<ndarray::Array1<f32>> = None;
-        for _ in 0..options.max_length.into() {
+        for i in 0..options.max_length.into() {
             let dec_emb = self
                 .k_emb
                 .forward(&ndarray::Array1::from_elem(1, *result.last().unwrap()));
@@ -278,7 +278,13 @@ impl S2s {
                 None => self.post_decoder.forward(&x.view(), None),
             };
             h2 = Some(h2_);
-            let x = self.fc.forward_2d(&x.view());
+            let mut x = self.fc.forward_2d(&x.view());
+
+            // 1文字目の場合は、終了トークンが出力されないようにする。
+            if i == 0 {
+                x[(0, constants::EOS_IDX,)] = 0.0;
+            }
+
             let x = x.index_axis(ndarray::Axis(0), 0);
             result.push(self.decode(&x.view(), &options.strategy));
             if result.last().unwrap() == &constants::EOS_IDX {


### PR DESCRIPTION
## 内容

タイトル通りです。
1文字目だけ`<EOS>`をf32::MINにするような実装にしました（top_pやtop_kがそれ自身の処理に集中できるのでこっちのほうがきれいに感じた）

## 関連 Issue

- closes: #51 

## スクリーンショット・動画など

（なし）

## その他

（なし）