### PR TITLE
chore(infer): strict -> error_on_invalid_input

### DIFF
--- a/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
+++ b/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
@@ -64,7 +64,7 @@ def convert(
     max_length : int, default 32
         最大の出力長。
     error_on_invalid_input : bool, default True
-        入力の検証を行うかどうか。
+        入力に無効な文字が含まれていた場合にエラーを返すかどうか。
         Falseの場合、無効な文字は無視されます。
     error_on_incomplete : bool, default True
         変換が終了しなかった場合にエラーを返すかどうか。

--- a/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
+++ b/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
@@ -17,7 +17,7 @@ def convert(
     /,
     *,
     max_length: int = 32,
-    strict: bool = True,
+    error_on_invalid_input: bool = True,
     error_on_incomplete: bool = True,
     strategy: Literal["greedy"] = "greedy",
 ) -> str: ...
@@ -27,7 +27,7 @@ def convert(
     /,
     *,
     max_length: int = 32,
-    strict: bool = True,
+    error_on_invalid_input: bool = True,
     error_on_incomplete: bool = True,
     strategy: Literal["top_k"],
     k: int = 10,
@@ -38,7 +38,7 @@ def convert(
     /,
     *,
     max_length: int = 32,
-    strict: bool = True,
+    error_on_invalid_input: bool = True,
     error_on_incomplete: bool = True,
     strategy: Literal["top_p"],
     p: float = 0.9,
@@ -50,7 +50,7 @@ def convert(
     *,
     max_length: int = 32,
     strategy: Strategy = "greedy",
-    strict: bool = True,
+    error_on_invalid_input: bool = True,
     error_on_incomplete: bool = True,
     **kwargs,
 ) -> str:
@@ -63,7 +63,7 @@ def convert(
         英単語。
     max_length : int, default 32
         最大の出力長。
-    strict : bool, default True
+    error_on_invalid_input : bool, default True
         入力の検証を行うかどうか。
         Falseの場合、無効な文字は無視されます。
     error_on_incomplete : bool, default True
@@ -80,8 +80,8 @@ def convert(
     Raises
     ------
     ValueError
-        - strictがTrue、かつ`word`が空文字列の場合。
-        - strictがTrue、かつ`word`にKanalizerの入力に使えない文字が含まれている場合。
+        - error_on_invalid_inputがTrue、かつ`word`が空文字列の場合。
+        - error_on_invalid_inputがTrue、かつ`word`にKanalizerの入力に使えない文字が含まれている場合。
         - `max_length`が0以下の場合。
     IncompleteConversionError
         - `error_on_incomplete`がTrue、かつ変換が終了しなかった場合。

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -90,11 +90,11 @@ fn extract_strategy(
 pyo3::import_exception!(kanalizer._error, IncompleteConversionError);
 
 #[pyfunction]
-#[pyo3(signature = (word, /, *, max_length = 32, strict = true, error_on_incomplete = true, strategy = "greedy", **kwargs))]
+#[pyo3(signature = (word, /, *, max_length = 32, error_on_invalid_input = true, error_on_incomplete = true, strategy = "greedy", **kwargs))]
 fn convert(
     word: &str,
     max_length: usize,
-    strict: bool,
+    error_on_invalid_input: bool,
     error_on_incomplete: bool,
     strategy: &str,
     kwargs: Option<&Bound<'_, PyDict>>,
@@ -105,7 +105,7 @@ fn convert(
             pyo3::exceptions::PyValueError::new_err("max_length must be a positive integer")
         })?)
         .with_strategy(&strategy)
-        .with_strict(strict)
+        .with_error_on_invalid_input(error_on_invalid_input)
         .with_error_on_incomplete(error_on_incomplete)
         .perform();
 

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -14,7 +14,7 @@ pub struct ConvertOptions {
     pub max_length: NonZero<usize>,
     /// デコードに使うアルゴリズム。
     pub strategy: Strategy,
-    /// 入力を検証する。
+    /// 入力に無効な文字が含まれている場合にエラーを返すかどうか。
     /// falseの場合、無効な文字は無視されます。
     pub error_on_invalid_input: bool,
     /// 変換が終了しなかった場合にエラーを返す。

--- a/infer/crates/kanalizer-rs/src/inference.rs
+++ b/infer/crates/kanalizer-rs/src/inference.rs
@@ -16,7 +16,7 @@ pub struct ConvertOptions {
     pub strategy: Strategy,
     /// 入力を検証する。
     /// falseの場合、無効な文字は無視されます。
-    pub strict: bool,
+    pub error_on_invalid_input: bool,
     /// 変換が終了しなかった場合にエラーを返す。
     pub error_on_incomplete: bool,
 }
@@ -26,7 +26,7 @@ impl Default for ConvertOptions {
         Self {
             max_length: 32.try_into().unwrap(),
             strategy: Strategy::default(),
-            strict: true,
+            error_on_invalid_input: true,
             error_on_incomplete: true,
         }
     }
@@ -427,7 +427,7 @@ impl Kanalizer {
 
     /// 変換を行う。
     pub fn convert(&self, input: &str, options: &ConvertOptions) -> Result<String> {
-        if options.strict {
+        if options.error_on_invalid_input {
             self.validate_input(input)?;
         }
         let input = input.chars().map(|c| c.to_string()).collect::<Vec<_>>();

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -64,8 +64,8 @@ impl ConvertBuilder {
 
     /// 入力を検証するかどうかを指定する。
     /// falseの場合、無効な文字は無視されます。
-    pub fn with_strict(mut self, strict: bool) -> Self {
-        self.options.strict = strict;
+    pub fn with_error_on_invalid_input(mut self, error_on_invalid_input: bool) -> Self {
+        self.options.error_on_invalid_input = error_on_invalid_input;
         self
     }
 

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -62,7 +62,7 @@ impl ConvertBuilder {
         self
     }
 
-    /// 入力を検証するかどうかを指定する。
+    /// 入力に無効な文字が含まれている場合にエラーを返すかどうかを指定する。
     /// falseの場合、無効な文字は無視されます。
     pub fn with_error_on_invalid_input(mut self, error_on_invalid_input: bool) -> Self {
         self.options.error_on_invalid_input = error_on_invalid_input;


### PR DESCRIPTION
## 内容

`strict`を`error_on_invalid_input`に改名します。
というのも、strictだと`error_on_incomplete`とかも有効化しそうで範囲が広そうだったので、公開する前に変えたほうがいいかなと。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）