### PR TITLE
chore(infer): kanalizer-modelに改名、リポジトリの分割を反映

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,17 +1,29 @@
 # メンテナンスガイドライン
 
-## モデル/データセットの更新
+## データセットの更新
 
-モデルやデータセットを更新する場合は、以下の手順に従ってください。
+データセットを更新する場合は、以下の手順に従ってください。
 
 1. Hugging Faceを更新する
-  1. [VOICEVOX/kanalizer](https://huggingface.co/VOICEVOX/kanalizer)をcloneする。
-  2. モデル/データセットの更新を行う。
-  3. PRを作成し、マージする。
-  4. `git tag v{バージョン番号}`でタグを打つ。
-  5. `git push origin v{バージョン番号}`でタグをpushする。
-2. Githubを更新する
-  1. `infer/crates/kanalizer-rs/build.rs`の`MODEL_TAG`を更新する。
+   1. [VOICEVOX/kanalizer-dataset](https://huggingface.co/datasets/VOICEVOX/kanalizer-dataset)をcloneする。
+   2. データセットの更新を行う。
+   3. PRを作成し、マージする。
+   4. `git tag v{バージョン番号}`でタグを打つ。
+   5. `git push origin v{バージョン番号}`でタグをpushする。
+2. 必要に応じて、モデルの学習を回す。
+
+## モデルの更新
+
+モデルを更新する場合は、以下の手順に従ってください。
+
+1. Hugging Faceを更新する
+   1. [VOICEVOX/kanalizer-model](https://huggingface.co/VOICEVOX/kanalizer-model)をcloneする。
+   2. モデルの更新を行う。
+   3. PRを作成し、マージする。
+   4. `git tag v{バージョン番号}`でタグを打つ。
+   5. `git push origin v{バージョン番号}`でタグをpushする。
+1. Githubを更新する
+   1. `infer/crates/kanalizer-rs/build.rs`の`MODEL_TAG`を更新する。
 
 ## リリース先の方針
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -22,7 +22,7 @@
    3. PRを作成し、マージする。
    4. `git tag v{バージョン番号}`でタグを打つ。
    5. `git push origin v{バージョン番号}`でタグをpushする。
-1. Githubを更新する
+2. Githubを更新する
    1. `infer/crates/kanalizer-rs/build.rs`の`MODEL_TAG`を更新する。
 
 ## リリース先の方針

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 ## Hugging Face
 
 Hugging Face にて、データセットと学習済みモデルを公開しています。\
-<https://huggingface.co/VOICEVOX/kanalizer>
+- データセット：<https://huggingface.co/datasets/VOICEVOX/kanalizer-dataset>
+- モデル：<https://huggingface.co/VOICEVOX/kanalizer-model>
 
 ## ライセンス
 

--- a/infer/crates/kanalizer-rs/build.rs
+++ b/infer/crates/kanalizer-rs/build.rs
@@ -64,7 +64,7 @@ fn prepare_huggingface_model() -> anyhow::Result<PathBuf> {
     if !latest_model_exists {
         download_to(
             &format!(
-                "https://huggingface.co/VOICEVOX/kanalizer/resolve/{MODEL_TAG}/model/c2k.safetensors"
+                "https://huggingface.co/VOICEVOX/kanalizer-model/resolve/{MODEL_TAG}/model/c2k.safetensors"
             ),
             &model_path,
         )?;


### PR DESCRIPTION
## 内容

- voicevox/kanalizerをkanalizer-modelにします。
- データセット周りの説明を更新します。

## 関連 Issue

- closes: #81 

## スクリーンショット・動画など

（なし）

## その他

（なし）