### PR TITLE
feat!(infer): Python側でエラーではなくwarningを吐けるように

### DIFF
--- a/infer/Cargo.lock
+++ b/infer/Cargo.lock
@@ -664,6 +664,7 @@ version = "0.0.0"
 dependencies = [
  "kanalizer",
  "pyo3",
+ "strum",
 ]
 
 [[package]]
@@ -1248,6 +1249,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/infer/crates/kanalizer-py/Cargo.toml
+++ b/infer/crates/kanalizer-py/Cargo.toml
@@ -13,3 +13,4 @@ crate-type = ["cdylib"]
 [dependencies]
 kanalizer = { path = "../kanalizer-rs" }
 pyo3 = { version = "0.24.0", features = ["extension-module", "abi3-py39"] }
+strum = { version = "0.27.1", features = ["derive"] }

--- a/infer/crates/kanalizer-py/python/kanalizer/__init__.py
+++ b/infer/crates/kanalizer-py/python/kanalizer/__init__.py
@@ -5,19 +5,29 @@ from ._error import (
     InvalidInputError,
     EmptyInputError,
     InvalidCharsError,
+    IncompleteConversionWarning,
+    InvalidInputWarning,
+    EmptyInputWarning,
+    InvalidCharsWarning,
 )
 
 if TYPE_CHECKING:
-    from ._rust import Strategy
+    from ._rust import Strategy, ErrorMode
 
 __all__ = [
     "__version__",
+    "convert",
     "INPUT_CHARS",
     "OUTPUT_CHARS",
-    "Strategy",
-    "convert",
     "IncompleteConversionError",
     "InvalidInputError",
     "EmptyInputError",
     "InvalidCharsError",
+    "IncompleteConversionWarning",
+    "InvalidInputWarning",
+    "EmptyInputWarning",
+    "InvalidCharsWarning",
+
+    "Strategy",
+    "ErrorMode",
 ]

--- a/infer/crates/kanalizer-py/python/kanalizer/__init__.py
+++ b/infer/crates/kanalizer-py/python/kanalizer/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
     "InvalidInputWarning",
     "EmptyInputWarning",
     "InvalidCharsWarning",
-
     "Strategy",
     "ErrorMode",
 ]

--- a/infer/crates/kanalizer-py/python/kanalizer/_error.py
+++ b/infer/crates/kanalizer-py/python/kanalizer/_error.py
@@ -33,9 +33,6 @@ class EmptyInputError(InvalidInputError):
     入力が空文字列の場合に発生するエラー。
     """
 
-    def __init__(self, message: str):
-        super().__init__(message)
-
 
 class InvalidCharsError(InvalidInputError):
     """
@@ -50,3 +47,41 @@ class InvalidCharsError(InvalidInputError):
     def __init__(self, message: str, invalid_chars: list[str]):
         super().__init__(message)
         self.invalid_chars = invalid_chars
+
+
+class IncompleteConversionWarning(Warning):
+    """
+    変換が終了しなかった場合に発生する警告。
+
+    IncompleteConversionErrorとは異なり、incomplete_output属性は存在しない。
+    """
+
+
+class InvalidInputWarning(Warning):
+    """
+    無効な入力が与えられた場合に発生する警告の基底クラス。
+
+    See Also
+    --------
+    InvalidCharsWarning
+        無効な文字が含まれている場合に発生する警告。
+    EmptyInputWarning
+        入力が空文字列の場合に発生する警告。
+    """
+
+
+class EmptyInputWarning(InvalidInputWarning):
+    """
+    入力が空文字列の場合に発生する警告。
+    """
+
+
+class InvalidCharsWarning(InvalidInputWarning):
+    """
+    入力に無効な文字が含まれていた場合に発生する警告。
+
+    InvalidCharsErrorとは異なり、invalid_chars属性は存在しない。
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
+++ b/infer/crates/kanalizer-py/python/kanalizer/_rust.pyi
@@ -11,14 +11,23 @@ OUTPUT_CHARS: Final[set[str]]
 Strategy = Literal["greedy", "top_k", "top_p"]
 """デコードのアルゴリズム。"""
 
+ErrorMode = Literal["error", "warning", "ignore"]
+"""
+エラー処理のモード。
+
+- "error" : エラーを発生させる。
+- "warning" : 警告を表示する。
+- "ignore" : エラーを無視する。
+"""
+
 @overload
 def convert(
     word: str,
     /,
     *,
     max_length: int = 32,
-    error_on_invalid_input: bool = True,
-    error_on_incomplete: bool = True,
+    on_invalid_input: ErrorMode = "error",
+    on_incomplete: ErrorMode = "warning",
     strategy: Literal["greedy"] = "greedy",
 ) -> str: ...
 @overload
@@ -27,8 +36,8 @@ def convert(
     /,
     *,
     max_length: int = 32,
-    error_on_invalid_input: bool = True,
-    error_on_incomplete: bool = True,
+    on_invalid_input: ErrorMode = "error",
+    on_incomplete: ErrorMode = "warning",
     strategy: Literal["top_k"],
     k: int = 10,
 ) -> str: ...
@@ -38,8 +47,8 @@ def convert(
     /,
     *,
     max_length: int = 32,
-    error_on_invalid_input: bool = True,
-    error_on_incomplete: bool = True,
+    on_invalid_input: ErrorMode = "error",
+    on_incomplete: ErrorMode = "warning",
     strategy: Literal["top_p"],
     p: float = 0.9,
     t: float = 1.0,
@@ -50,8 +59,8 @@ def convert(
     *,
     max_length: int = 32,
     strategy: Strategy = "greedy",
-    error_on_invalid_input: bool = True,
-    error_on_incomplete: bool = True,
+    on_invalid_input: ErrorMode = "error",
+    on_incomplete: ErrorMode = "warning",
     **kwargs,
 ) -> str:
     """
@@ -63,11 +72,11 @@ def convert(
         英単語。
     max_length : int, default 32
         最大の出力長。
-    error_on_invalid_input : bool, default True
-        入力に無効な文字が含まれていた場合にエラーを返すかどうか。
-        Falseの場合、無効な文字は無視されます。
-    error_on_incomplete : bool, default True
-        変換が終了しなかった場合にエラーを返すかどうか。
+    on_invalid_input : ErrorMode, default "error"
+        入力に無効な文字が含まれていた場合の挙動。
+        "error"以外の場合は、無効な文字を無視して変換を続行する。
+    on_incomplete : ErrorMode, default "warning"
+        変換が終了しなかった場合の挙動。
     strategy : Strategy, default "greedy"
         デコードのアルゴリズム。
     k : int, default 10

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -96,7 +96,8 @@ fn convert(
 
     fn do_warn<T: pyo3::PyTypeInfo>(py: Python, err: &kanalizer::Error) -> PyResult<()> {
         let pyerr = py.get_type::<T>();
-        let message_cstr = std::ffi::CString::new(err.to_string()).expect("should not contain nul byte");
+        let message_cstr =
+            std::ffi::CString::new(err.to_string()).expect("should not contain nul byte");
         pyo3::PyErr::warn(py, &pyerr, &message_cstr, 0)
     }
 }

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -96,7 +96,7 @@ fn convert(
 
     fn do_warn<T: pyo3::PyTypeInfo>(py: Python, err: &kanalizer::Error) -> PyResult<()> {
         let pyerr = py.get_type::<T>();
-        let message_cstr = std::ffi::CString::new(err.to_string()).unwrap();
+        let message_cstr = std::ffi::CString::new(err.to_string()).expect("should not contain nul byte");
         pyo3::PyErr::warn(py, &pyerr, &message_cstr, 0)
     }
 }

--- a/infer/crates/kanalizer-py/src/lib.rs
+++ b/infer/crates/kanalizer-py/src/lib.rs
@@ -22,6 +22,8 @@ fn convert(
     strategy: &str,
     kwargs: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<String> {
+    // NOTE:
+    // ErrorMode::Warningを指定している場合は、エラーを吐くようにし、Warningを吐いてからErrorMode::Ignoreにして再度呼び出す
     let rust_strategy = extract_strategy(strategy, kwargs)?;
     let result = kanalizer::convert(word)
         .with_max_length(max_length.try_into().map_err(|_| {
@@ -32,6 +34,7 @@ fn convert(
         .with_error_on_incomplete(on_incomplete != ErrorMode::Ignore)
         .perform();
 
+    // TODO: このmatch文をすっきりさせる
     return match result {
         Ok(dst) => Ok(dst),
         Err(err @ kanalizer::Error::EmptyInput) if on_invalid_input == ErrorMode::Warning => {

--- a/infer/crates/kanalizer-py/test_main.py
+++ b/infer/crates/kanalizer-py/test_main.py
@@ -14,20 +14,35 @@ def test_invalid_max_length():
         kanalizer.convert(word, max_length=0)
 
 
-def test_empty_word():
+def test_empty_word_error():
     word = ""
     with pytest.raises(kanalizer.EmptyInputError):
-        kanalizer.convert(word)
+        kanalizer.convert(word, on_invalid_input="error")
+
+
+def test_empty_word_warning():
+    word = ""
+    with pytest.warns(kanalizer.EmptyInputWarning):
+        assert kanalizer.convert(word, on_invalid_input="warning") == ""
 
 
 @pytest.mark.parametrize(
     "word",
     [("あ"), ("A")],
 )
-def test_invalid_chars(word: str):
+def test_invalid_chars_error(word: str):
     with pytest.raises(kanalizer.InvalidCharsError) as ce:
-        kanalizer.convert(word)
+        kanalizer.convert(word, on_invalid_input="error")
     assert ce.value.invalid_chars == [word]
+
+
+@pytest.mark.parametrize(
+    "word",
+    [("あ"), ("A")],
+)
+def test_invalid_chars_warning(word: str):
+    with pytest.warns(kanalizer.InvalidCharsWarning):
+        kanalizer.convert(word, on_invalid_input="warning")
 
 
 def test_inference_not_finished_error():
@@ -36,4 +51,10 @@ def test_inference_not_finished_error():
         kanalizer.IncompleteConversionError,
         match=r'変換が終了しませんでした：".+"',
     ):
-        kanalizer.convert(word, max_length=5)
+        kanalizer.convert(word, max_length=5, on_incomplete="error")
+
+
+def test_inference_not_finished_warning():
+    word = "phosphoribosylaminoimidazolesuccinocarboxamide"
+    with pytest.warns(kanalizer.IncompleteConversionWarning):
+        kanalizer.convert(word, max_length=5, on_incomplete="warning")


### PR DESCRIPTION
## 内容

それぞれのエラーのWarning版を追加し、オプションで吐けるようにします。

BREAKING CHANGE: error_on_incomplete = Trueはon_incomplete = "error"のようになりました。

## 関連 Issue

- ref: #58 

## スクリーンショット・動画など

（なし）

## その他

（なし）