### PR TITLE
feat!(train): 学習率の減衰率設定を削除し、schedulefreeライブラリを追加

### DIFF
--- a/train/config/example.yml
+++ b/train/config/example.yml
@@ -17,5 +17,3 @@ num_best_models_to_keep: 2
 seed: 0
 # Optimizerの学習率
 optimizer_lr: 0.001
-# 学習率の減衰率
-exponential_lr_scheduler_gamma: 0.9

--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -17,4 +17,5 @@ dependencies = [
   "torch==2.5.0",
   "torcheval>=0.0.7",
   "pyyaml>=6.0.2",
+  "schedulefree>=1.4.1",
 ]

--- a/train/src/config.py
+++ b/train/src/config.py
@@ -28,7 +28,6 @@ class Config:
     num_best_models_to_keep: int
     seed: int
     optimizer_lr: float
-    exponential_lr_scheduler_gamma: float
 
     @classmethod
     def from_dict(cls, config: dict):

--- a/train/src/config.py
+++ b/train/src/config.py
@@ -10,8 +10,9 @@ def migrate(config: dict):
 
     if "optimizer_lr" not in config:
         config["optimizer_lr"] = 1e-3
-    if "exponential_lr_scheduler_gamma" not in config:
-        config["exponential_lr_scheduler_gamma"] = 0.9
+
+    if "exponential_lr_scheduler_gamma" in config:
+        del config["exponential_lr_scheduler_gamma"]
 
     return config
 

--- a/train/uv.lock
+++ b/train/uv.lock
@@ -221,6 +221,7 @@ dependencies = [
     { name = "requests" },
     { name = "ruff" },
     { name = "safetensors" },
+    { name = "schedulefree" },
     { name = "tensorboard" },
     { name = "torch" },
     { name = "torcheval" },
@@ -236,6 +237,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3" },
     { name = "ruff", specifier = ">=0.10.0" },
     { name = "safetensors", specifier = ">=0.5.2" },
+    { name = "schedulefree", specifier = ">=1.4.1" },
     { name = "tensorboard", specifier = ">=2.18.0" },
     { name = "torch", specifier = "==2.5.0" },
     { name = "torcheval", specifier = ">=0.0.7" },
@@ -671,6 +673,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/40/ad/2b113098e69c985a3d8fbda4b902778eae4a35b7d5188859b4a63d30c161/safetensors-0.5.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:37f1521be045e56fc2b54c606d4455573e717b2d887c579ee1dbba5f868ece04", size = 643147 },
     { url = "https://files.pythonhosted.org/packages/0a/0c/95aeb51d4246bd9a3242d3d8349c1112b4ee7611a4b40f0c5c93b05f001d/safetensors-0.5.3-cp38-abi3-win32.whl", hash = "sha256:cfc0ec0846dcf6763b0ed3d1846ff36008c6e7290683b61616c4b040f6a54ace", size = 296677 },
     { url = "https://files.pythonhosted.org/packages/69/e2/b011c38e5394c4c18fb5500778a55ec43ad6106126e74723ffaee246f56e/safetensors-0.5.3-cp38-abi3-win_amd64.whl", hash = "sha256:836cbbc320b47e80acd40e44c8682db0e8ad7123209f69b093def21ec7cafd11", size = 308878 },
+]
+
+[[package]]
+name = "schedulefree"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/51/d78369c32b0f3818ee7f5a04e77ed02a6bd0ba8642462f780623af0010f5/schedulefree-1.4.1.tar.gz", hash = "sha256:69ef25601d1fc0d8dd00cb36f9af78833f88b7846f1bb6ddecc9f144f3e9f7cb", size = 29281 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/ef/aac74263f0252806b46f0fd5a52566ee06129744572d0958cd0a77d22b0a/schedulefree-1.4.1-py3-none-any.whl", hash = "sha256:21602d3a0d35ee190152e3d56f547ea725d316310bd198fa6108f8039386b242", size = 55068 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 内容

学習率の減衰率がスケジュールされているのをなくし、スケジュールが不要な手法に変えてみました。

この記事のです。
https://zenn.dev/dena/articles/6f04641801b387

現在比較実験中です。たぶん性能は変わらなさそう。（だとするとハイパラが１つ減るので嬉しい）


## その他
