### PR TITLE
feat(config): use_layernormオプションを追加し、モデルに適用

### DIFF
--- a/train/config/example.yml
+++ b/train/config/example.yml
@@ -17,5 +17,7 @@ num_best_models_to_keep: 2
 seed: 0
 # Optimizerの学習率
 optimizer_lr: 0.001
+# 学習率の減衰率
+exponential_lr_scheduler_gamma: 0.9
 # LayerNormを使うかどうか
 use_layernorm: true

--- a/train/config/example.yml
+++ b/train/config/example.yml
@@ -17,5 +17,5 @@ num_best_models_to_keep: 2
 seed: 0
 # Optimizerの学習率
 optimizer_lr: 0.001
-# 学習率の減衰率
-exponential_lr_scheduler_gamma: 0.9
+# LayerNormを使うかどうか
+use_layernorm: true

--- a/train/src/config.py
+++ b/train/src/config.py
@@ -13,6 +13,9 @@ def migrate(config: dict):
     if "exponential_lr_scheduler_gamma" not in config:
         config["exponential_lr_scheduler_gamma"] = 0.9
 
+    if "use_layernorm" not in config:
+        config["use_layernorm"] = False
+
     return config
 
 
@@ -27,7 +30,7 @@ class Config:
     num_best_models_to_keep: int
     seed: int
     optimizer_lr: float
-    exponential_lr_scheduler_gamma: float
+    use_layernorm: bool
 
     @classmethod
     def from_dict(cls, config: dict):

--- a/train/src/config.py
+++ b/train/src/config.py
@@ -30,6 +30,7 @@ class Config:
     num_best_models_to_keep: int
     seed: int
     optimizer_lr: float
+    exponential_lr_scheduler_gamma: float
     use_layernorm: bool
 
     @classmethod


### PR DESCRIPTION
## 内容

transformer系ならまあ大体入ってる気がするlayernormを入れてみました。
その層を通る出力を正則化してくれる系の層で可変長にも使えるやつです。
理屈上は過学習が抑えられる方向に働いてくれる。

まあとりあえず悪い方向には働いてなさそう。
（オレンジ：schedulefreeモデル　青：schedulefree+layernormモデル）

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/aeebeba8-a8bf-4f7d-b5e9-97362f6f5c99" />

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/6e5568f4-8410-4a4a-a2c8-135d463e6283" />


## その他
