### PR TITLE
feat(train): weight_decayオプションを追加し、最適化器に適用

### DIFF
--- a/train/config/example.yml
+++ b/train/config/example.yml
@@ -8,7 +8,7 @@ eval_max_words: 100
 # モデルの次元数。
 dim: 256
 # 学習するエポック数。
-max_epochs: 10
+max_epochs: 15
 # 最新のエポックから保存するモデルの数。
 num_last_models_to_keep: 2
 # 保存する上位のモデルの数。
@@ -19,3 +19,5 @@ seed: 0
 optimizer_lr: 0.001
 # 学習率の減衰率
 exponential_lr_scheduler_gamma: 0.9
+# Optimizerのweight_decay（L2正則化）
+weight_decay: 0.2

--- a/train/src/config.py
+++ b/train/src/config.py
@@ -13,6 +13,9 @@ def migrate(config: dict):
     if "exponential_lr_scheduler_gamma" not in config:
         config["exponential_lr_scheduler_gamma"] = 0.9
 
+    if "weight_decay" not in config:
+        config["weight_decay"] = 0
+
     return config
 
 
@@ -28,6 +31,7 @@ class Config:
     seed: int
     optimizer_lr: float
     exponential_lr_scheduler_gamma: float
+    weight_decay: float
 
     @classmethod
     def from_dict(cls, config: dict):

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -257,7 +257,7 @@ def train():
     )
 
     criterion = nn.CrossEntropyLoss(ignore_index=0)
-    optimizer = torch.optim.Adam(model.parameters(), lr=config.optimizer_lr)
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.optimizer_lr, weight_decay=config.weight_decay)
     scheduler = ExponentialLR(optimizer, config.exponential_lr_scheduler_gamma)
     writer = SummaryWriter(log_dir=output_dir)
     evaluator = Evaluator(eval_dataset)


### PR DESCRIPTION
## 内容

よく使われるイメージのある正則化手法、weight decayを設定できるオプションを追加してみました。
たしか、重みの２乗をlossに加えることで、極端に重みが大きくなることを抑制してくれる正則化手法です。

だいたい0.001とかそれくらいの値を設定するイメージなのですが、相当大きい値（0.1とか0.2とか）を指定すると効き始めました。
ぶっちゃけ結果はあんまり変わりませんでした。

## その他

0を指定すると今まで通りです。（Adam等のweight_decay引数のデフォルト値が0）
