### PR TITLE
feat!(train): Loss/eval基準でもモデルを残すように

### DIFF
--- a/train/src/train.py
+++ b/train/src/train.py
@@ -70,10 +70,10 @@ class ModelKeeper:
             if removed_epoch == current_epoch:
                 print(f"[{self.label}] Will not save the current model")
                 return
-            else:
-                path = self.output_dir / f"model-{self.label}-e{removed_epoch}.pth"
-                print(f"[{self.label}] Removing {path}")
-                os.remove(path)
+
+            path = self.output_dir / f"model-{self.label}-e{removed_epoch}.pth"
+            print(f"[{self.label}] Removing {path}")
+            path.unlink()
 
         path = self.output_dir / f"model-{self.label}-e{current_epoch}.pth"
         print(f"[{self.label}] Saving {path}")

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -71,11 +71,11 @@ class ModelKeeper:
                 print(f"[{self.label}] Will not save the current model")
                 return
             else:
-                path = self.output_dir / f"model-best-{self.label}-e{removed_epoch}.pth"
+                path = self.output_dir / f"model-{self.label}-e{removed_epoch}.pth"
                 print(f"[{self.label}] Removing {path}")
                 os.remove(path)
 
-        path = self.output_dir / f"model-best-{self.label}-e{current_epoch}.pth"
+        path = self.output_dir / f"model-{self.label}-e{current_epoch}.pth"
         print(f"[{self.label}] Saving {path}")
         torch.save(self.model.state_dict(), path)
 
@@ -307,11 +307,11 @@ def train():
     )
     # BLEUスコアが高いものを保存する
     bleu_keeper = ModelKeeper(
-        "bleu", model, output_dir, config.num_best_models_to_keep, "max"
+        "best-bleu", model, output_dir, config.num_best_models_to_keep, "max"
     )
     # Loss/evalが低いものを保存する
     loss_keeper = ModelKeeper(
-        "loss", model, output_dir, config.num_best_models_to_keep, "min"
+        "best-loss", model, output_dir, config.num_best_models_to_keep, "min"
     )
 
     shutil.copyfile(

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -37,8 +37,8 @@ class ModelKeeper:
     model: nn.Module
     output_dir: Path
     num_models_to_keep: int
-    # maxはスコアが大きいものを残す、minはスコアが小さいものを残す
     compare_mode: Literal["max", "min"]
+    """maxはスコアが大きいものを残す、minはスコアが小さいものを残す"""
 
     models: list[tuple[int, int | float]]
 

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -32,7 +32,7 @@ def word_to_tensor(word: str, device: torch.device) -> torch.Tensor:
     return torch.tensor(indices, device=device)
 
 
-class ModelKeeper:
+class CheckpointManager:
     label: str
     model: nn.Module
     output_dir: Path
@@ -57,7 +57,7 @@ class ModelKeeper:
         self.compare_mode = compare_mode
         self.models = []
 
-    def step(
+    def update(
         self,
         current_epoch: int,
         current_score: int | float,
@@ -302,15 +302,15 @@ def train():
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # 最新epochを保存する
-    latest_keeper = ModelKeeper(
+    latest_keeper = CheckpointManager(
         "latest", model, output_dir, config.num_last_models_to_keep, "max"
     )
     # BLEUスコアが高いものを保存する
-    bleu_keeper = ModelKeeper(
+    bleu_keeper = CheckpointManager(
         "best-bleu", model, output_dir, config.num_best_models_to_keep, "max"
     )
     # Loss/evalが低いものを保存する
-    loss_keeper = ModelKeeper(
+    loss_keeper = CheckpointManager(
         "best-loss", model, output_dir, config.num_best_models_to_keep, "min"
     )
 
@@ -415,9 +415,9 @@ def train():
         print(f"Epoch {epoch} Sample: {src} -> {pred}")
 
         # save the model
-        latest_keeper.step(epoch, epoch)
-        bleu_keeper.step(epoch, float(test_bleu))
-        loss_keeper.step(epoch, test_loss)
+        latest_keeper.update(epoch, epoch)
+        bleu_keeper.update(epoch, float(test_bleu))
+        loss_keeper.update(epoch, test_loss)
 
 
 def prepare_datasets(config: Config, device: torch.device):

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -417,7 +417,7 @@ def train():
         # save the model
         latest_keeper.step(epoch, epoch)
         bleu_keeper.step(epoch, float(test_bleu))
-        loss_keeper.step(epoch, eval_loss)
+        loss_keeper.step(epoch, test_loss)
 
 
 def prepare_datasets(config: Config, device: torch.device):

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -50,7 +50,7 @@ class CheckpointManager:
         self._compare_mode = compare_mode
         self._models: dict[int, float] = {}
 
-    def step(self, new_epoch: int, score: int | float) -> None:
+    def update(self, new_epoch: int, score: int | float) -> None:
         worst_epoch = self._worst({**self._models, new_epoch: score})
 
         if len(self._models) < self._limit or worst_epoch != new_epoch:

--- a/train/src/train.py
+++ b/train/src/train.py
@@ -34,7 +34,7 @@ def word_to_tensor(word: str, device: torch.device) -> torch.Tensor:
 
 class ModelKeeper:
     label: str
-    madel: nn.Module
+    model: nn.Module
     output_dir: Path
     num_models_to_keep: int
     # maxはスコアが大きいものを残す、minはスコアが小さいものを残す


### PR DESCRIPTION
## 内容

モデルを残すコードを共通化し、Loss/eval基準でもモデルを残すようにします。

## 関連 Issue

- closes: #106

## スクリーンショット・動画など

（なし）

## その他

共通化の都合上、最新epochのモデルの名前が変わるので、 #112 が先。