### PR TITLE
feat(infer): kanalizer-rsのMSRVを1.84に

### DIFF
--- a/infer/crates/kanalizer-rs/Cargo.toml
+++ b/infer/crates/kanalizer-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kanalizer"
 version.workspace = true
-edition.workspace = true
+edition = "2021"
 license.workspace = true
 exclude = ["tasks", "models"]
 description.workspace = true
@@ -20,7 +20,7 @@ compress_model = ["dep:brotli-decompressor"]
 [dependencies]
 anyhow = "1.0.95"
 brotli-decompressor = { version = "4.0.2", optional = true }
-cfg-elif = "0.6.3"
+cfg-elif = "0.6.2"
 clap = { version = "4.5.29", features = ["derive"] }
 duplicate = "2.0.0"
 educe = "0.6.0"

--- a/infer/crates/kanalizer-rs/benches/benchmark.rs
+++ b/infer/crates/kanalizer-rs/benches/benchmark.rs
@@ -1,3 +1,4 @@
+#[rustfmt::skip] // TODO: Rust 2024に移行したらこの抑制をやめる
 use criterion::{Criterion, criterion_group, criterion_main};
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/infer/crates/kanalizer-rs/src/lib.rs
+++ b/infer/crates/kanalizer-rs/src/lib.rs
@@ -120,6 +120,7 @@ mod tests {
             .iter()
             .map(|&c| c.to_string())
             .collect();
+        #[rustfmt::skip] // TODO: Rust 2024に移行したらこの抑制をやめる
         assert!(
             INPUT_CHARS
                 .iter()
@@ -133,6 +134,7 @@ mod tests {
     fn test_output_chars() {
         // OUTPUT_CHARSがKANASのサブセットであることを確認する。
         let kana_entries: HashSet<_> = constants::KANAS.iter().map(|&c| c.to_string()).collect();
+        #[rustfmt::skip] // TODO: Rust 2024に移行したらこの抑制をやめる
         assert!(
             OUTPUT_CHARS
                 .iter()


### PR DESCRIPTION
## 内容

VOICEVOX CORE Rust APIのMSRVである1.84で動くようにする。

VOICEVOX/voicevox_core#1141 でやったようなCIを入れるかについては、voicevox_core側で十分な気がするので見送る。
(edition跨ぎをするために面倒なワークアラウンドをやっているので、その点でもYAGNIっておきたい)

## 関連 Issue

## スクリーンショット・動画など

## その他
