### PR TITLE
ci: pinact でGitHub Actionsのバージョンを固定する

### DIFF
--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -8,7 +8,3 @@ files:
 ignore_actions:
   - name: voicevox/merge-gatekeeper
     ref: main
-  - name: cargo-bins/cargo-binstall
-    ref: main
-  - name: pypa/gh-action-pypi-publish
-    ref: release/v1

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/actions/*/action.yml"
+
+ignore_actions:
+  - name: voicevox/merge-gatekeeper
+    ref: main
+  - name: cargo-bins/cargo-binstall
+    ref: main
+  - name: pypa/gh-action-pypi-publish
+    ref: release/v1

--- a/.github/workflows/build_and_deploy_infer.yml
+++ b/.github/workflows/build_and_deploy_infer.yml
@@ -66,7 +66,7 @@ jobs:
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Setup binstall
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@0b24824336e2b3800b0f89d9e08b2c08bfa3dcdd # v1.17.9
 
       - name: Setup cargo-about
         run: cargo binstall cargo-about cargo-edit
@@ -110,7 +110,7 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: ${{ inputs.production && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
           verbose: true

--- a/.github/workflows/build_and_deploy_infer.yml
+++ b/.github/workflows/build_and_deploy_infer.yml
@@ -60,10 +60,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Setup binstall
         uses: cargo-bins/cargo-binstall@main
@@ -82,7 +82,7 @@ jobs:
           uv run build_kanalizer_py.py ${{ matrix.build_args }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: kanalizer-py-${{ matrix.os }}
           path: |
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: kanalizer-py-*
           merge-multiple: true
@@ -117,7 +117,7 @@ jobs:
 
       - name: Create release
         if: inputs.production
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ inputs.version }}
           target_commitish: ${{ github.sha }}

--- a/.github/workflows/merge_gatekeeper.yml
+++ b/.github/workflows/merge_gatekeeper.yml
@@ -21,7 +21,7 @@ jobs:
           score_rules: |
             #maintainer: 2
             #reviewer: 1
-      - uses: upsidr/merge-gatekeeper@v1
+      - uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           self: merge_gatekeeper

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     paths:
       - ".github/**"
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -3,6 +3,8 @@ name: Check pinact
 on:
   push:
   pull_request:
+    paths:
+      - ".github/**"
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,22 @@
+name: Check pinact
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Check pinact
+        uses: suzuki-shunsuke/pinact-action@28aeb220eb3252ad0d4422dd5d9368e925acbd8d # v1.3.0
+        with:
+          skip_push: "true"
+          min_age: "7"

--- a/.github/workflows/test_dataset.yml
+++ b/.github/workflows/test_dataset.yml
@@ -16,17 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           package_json_file: dataset/package.json
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: dataset/.node-version
           cache: "pnpm"

--- a/.github/workflows/test_infer.yml
+++ b/.github/workflows/test_infer.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: "infer"
 

--- a/.github/workflows/test_train.yml
+++ b/.github/workflows/test_train.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 

--- a/README.md
+++ b/README.md
@@ -17,19 +17,6 @@ Hugging Face にて、データセットと学習済みモデルを公開して�
 - データセット：<https://huggingface.co/datasets/VOICEVOX/kanalizer-dataset>
 - モデル：<https://huggingface.co/VOICEVOX/kanalizer-model>
 
-## GitHub Actions のバージョン固定
-
-[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
-プルリクエストを送ると自動でテストされます。
-
-```bash
-# バージョンを固定する
-pinact run
-
-# バージョンを更新して固定する
-pinact run --update --min-age 7
-```
-
 ## ライセンス
 
 このリポジトリのコードはMITライセンスのもとで公開されています。

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Hugging Face にて、データセットと学習済みモデルを公開して�
 - データセット：<https://huggingface.co/datasets/VOICEVOX/kanalizer-dataset>
 - モデル：<https://huggingface.co/VOICEVOX/kanalizer-model>
 
+## GitHub Actions のバージョン固定
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) を使って GitHub Actions のバージョンを full-length commit SHA に固定しています。
+プルリクエストを送ると自動でテストされます。
+
+```bash
+# バージョンを固定する
+pinact run
+
+# バージョンを更新して固定する
+pinact run --update --min-age 7
+```
+
 ## ライセンス
 
 このリポジトリのコードはMITライセンスのもとで公開されています。


### PR DESCRIPTION
## 内容

pinact で GitHub Actions のバージョンを full-length commit SHA にピン留めする。

## 関連 Issue

ref VOICEVOX/voicevox_project#82